### PR TITLE
Update spokestack-android support; improve API word choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ Spokestack.initialize({
   }
 });
 
-// Start and stop the speech pipeline. start() and stop() can be called repeatedly.
-Spokestack.start(); // start voice activity detection and speech recognition. can only start after initialize is called.
-Spokestack.stop(); // stop voice activity detection and speech recognition. can only start after initialize is called
+// Start and stop the speech pipeline. All methods can be called repeatedly.
+Spokestack.start(); // start speech pipeline. can only start after initialize is called.
+Spokestack.stop(); // stop speech pipeline
+Spokestack.activate() // manually activate the speech pipeline. The speech pipeline is now actively listening for speech to recognize.
+Spokestack.deactivate() // manually deactivate the speech pipeline. The speech pipeline is now passively waiting for an activation trigger.
 
 // Binding events
 const logEvent = e => console.log(e);
@@ -128,11 +130,13 @@ Spokestack.onRecognize = e => {
 
 ### Methods
 
-| Method Name                | Description                                                                     | Platform |
-| -------------------------- | ------------------------------------------------------------------------------- | -------- |
-| Spokestack.initialize()    | Initialize the Spokestack VAD/ASR pipeline; required for `start()` and `stop()` | Android  |
-| Spokestack.start()         | Starts listening for speech activity                                            | Android  |
-| Spokestack.stop()          | Stops listening for speech activity                                             | Android  |
+| Method Name                | Description                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| Spokestack.initialize()    | Initialize the speech pipeline; required for all other methods                        |
+| Spokestack.start()         | Starts the speech pipeline. The speech pipeline starts in the `deactivate` state. |
+| Spokestack.stop()          | Stops the speech pipeline                                                       |
+| Spokestack.activate()      | Manually activate the speech pipeline                                           |
+| Spokestack.deactivate()    | Manually deactivate the speech pipeline                                         |
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Spokestack.initialize({
     locale: "en-US",
     "google-credentials": YOUR_GOOGLE_VOICE_CREDENTIALS,
     // 'bing-speech-api-key': YOUR_BING_VOICE_CREDENTIALS,
-    trace-level: "DEBUG" //"PERF", "INFO"
+    trace-level: Spokestack.TraceLevel.DEBUG
   }
 });
 
@@ -126,11 +126,15 @@ Spokestack.onSpeechRecognized = e => {
 
 ## API
 
+### Methods
+
 | Method Name                | Description                                                                     | Platform |
 | -------------------------- | ------------------------------------------------------------------------------- | -------- |
 | Spokestack.initialize()    | Initialize the Spokestack VAD/ASR pipeline; required for `start()` and `stop()` | Android  |
 | Spokestack.start()         | Starts listening for speech activity                                            | Android  |
 | Spokestack.stop()          | Stops listening for speech activity                                             | Android  |
+
+### Events
 
 | Event Name                           | Property | Description                             |
 | ------------------------------------ | -------- | --------------------------------------- |
@@ -139,6 +143,16 @@ Spokestack.onSpeechRecognized = e => {
 | Spokestack.onSpeechRecognized(event) | `transcript`:`string` | Invoked when speech has been recognized |
 | Spokestack.onTrace(event)            | `message`:`string` | Invoked when a trace message become available |
 | Spokestack.onError(event)            | `error`:`string`       | Invoked upon an error in the speech pipeline execution |
+
+### Enums
+
+| TraceLevel                           |    Value |
+| ------------------------------------ | -------- |
+| DEBUG                                |       10 |
+| PERF                                 |       20 |
+| INFO                                 |       30 |
+| NONE                                 | 100      |
+
 ## Gotchas
 
 - Requires Android SDK 26 level support

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Spokestack.stop(); // stop voice activity detection and speech recognition. can 
 
 // Binding events
 const logEvent = e => console.log(e);
-Spokestack.onSpeechStarted = logEvent;
-Spokestack.onSpeechEnded = logEvent;
+Spokestack.onActivate = logEvent;
+Spokestack.onDeactivate = logEvent;
 Spokestack.onError = e => {
   Spokestack.stop();
   logEvent(e);
@@ -117,7 +117,7 @@ Spokestack.onTrace = e => { // subscribe to tracing events according to the trac
   logEvent(e);
   console.log(e.message);
 }
-Spokestack.onSpeechRecognized = e => {
+Spokestack.onRecognize = e => {
   logEvent(e);
   console.log(e.transcript); // "Hello Spokestack"
 };
@@ -138,9 +138,9 @@ Spokestack.onSpeechRecognized = e => {
 
 | Event Name                           | Property | Description                             |
 | ------------------------------------ | -------- | --------------------------------------- |
-| Spokestack.onSpeechStarted(event)    | `null`   | Invoked when speech is recognized       |
-| Spokestack.onSpeechEnded(event)      | `null`   | Invoked when speech has stopped         |
-| Spokestack.onSpeechRecognized(event) | `transcript`:`string` | Invoked when speech has been recognized |
+| Spokestack.onActivate(event)           | `null`   | Invoked when the speech pipeline is activated, which enables the speech recognizer and begins a new dialogue session                          |
+| Spokestack.onDeactivate(event)       | `null`   | Invoked when the speech pipeline has been deactivated |
+| Spokestack.onRecognize(event)        | `transcript`:`string` | Invoked when speech has been recognized |
 | Spokestack.onTrace(event)            | `message`:`string` | Invoked when a trace message become available |
 | Spokestack.onError(event)            | `error`:`string`       | Invoked upon an error in the speech pipeline execution |
 

--- a/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
@@ -77,6 +77,16 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
     pipeline.stop();
   }
 
+  @ReactMethod
+  public void activate () {
+    pipeline.getContext().setActive(true);
+  }
+
+  @ReactMethod
+  public void deactivate () {
+    pipeline.getContext().setActive(false);
+  }
+
   public void onEvent(SpeechContext.Event event, SpeechContext context) {
     WritableMap react_event = Arguments.createMap();
     react_event.putString("event", event.name());

--- a/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
@@ -58,37 +58,13 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
     }
 
     if (config.hasKey("properties")) {
-      constructProperties(config, builder);
+      Map<String, Object> map = config.getMap("properties").toHashMap();
+      for (String k: map.keySet())
+        builder.setProperty(k, map.get(k))
     }
     builder.addOnSpeechEventListener(this);
 
     pipeline = builder.build();
-  }
-
-  private void constructProperties(ReadableMap config, SpeechPipeline.Builder builder) {
-    Log.d("ReactNative", "constructProperties");
-    Map<String, Object> map = config.getMap("properties").toHashMap();
-    for (String k: map.keySet()) {
-      if (k.equals("trace-level")) {
-        try {
-          int l = SpeechContext.TraceLevel.valueOf(map
-                                                   .get(k)
-                                                   .toString()
-                                                   .trim()
-                                                   .toUpperCase(Locale.US)
-                                                   ).value();
-          builder.setProperty("trace-level", l);
-        } catch (IllegalArgumentException ex) {
-          WritableMap react_event = Arguments.createMap();
-          react_event.putString("event", "error");
-          react_event.putString("error", "The trace-level " + map.get(k) + " is not supported. Supported values are: " + java.util.Arrays.toString(SpeechContext.TraceLevel.values()));
-          sendEvent("onSpeechEvent", react_event);
-        }
-      }
-      else {
-        builder.setProperty(k, map.get(k));
-      }
-    }
   }
 
   @ReactMethod

--- a/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
@@ -80,11 +80,13 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
   @ReactMethod
   public void activate () {
     pipeline.getContext().setActive(true);
+    pipeline.getContext().dispatch(SpeechContext.Event.ACTIVATE);
   }
 
   @ReactMethod
   public void deactivate () {
     pipeline.getContext().setActive(false);
+    pipeline.getContext().dispatch(SpeechContext.Event.DEACTIVATE);
   }
 
   public void onEvent(SpeechContext.Event event, SpeechContext context) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,18 @@ import {
 const { Spokestack } = NativeModules
 const spokestackEmitter = new NativeEventEmitter(Spokestack)
 
+const TraceLevel = Object.freeze({
+  DEBUG: 10,
+  PERF: 20,
+  INFO: 30,
+  NONE: 100
+})
+
 class RNSpokestack {
+  get TraceLevel () {
+    return TraceLevel
+  }
+
   // Class methods
 
   constructor () {

--- a/index.js
+++ b/index.js
@@ -54,6 +54,14 @@ class RNSpokestack {
     Spokestack.stop()
   }
 
+  activate () {
+    Spokestack.activate()
+  }
+
+  deactivate () {
+    Spokestack.deactivate()
+  }
+
   // Events
 
   _onSpeechEvent (e) {

--- a/index.js
+++ b/index.js
@@ -59,18 +59,18 @@ class RNSpokestack {
   _onSpeechEvent (e) {
     switch (e.event.toLowerCase()) {
       case 'activate':
-        if (this.onSpeechStarted) {
-          this.onSpeechStarted(e)
+        if (this.onActivate) {
+          this.onActivate(e)
         }
         break
       case 'deactivate':
-        if (this.onSpeechEnded) {
-          this.onSpeechEnded(e)
+        if (this.onDeactivate) {
+          this.onDeactivate(e)
         }
         break
       case 'recognize':
-        if (this.onSpeechRecognized) {
-          this.onSpeechRecognized(e)
+        if (this.onRecognize) {
+          this.onRecognize(e)
         }
         break
       case 'trace':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-spokestack",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "React Native wrapper for Spokestack",
   "main": "index.js",
   "author": "Noel Weichbrodt <noel@pylon.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-spokestack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React Native wrapper for Spokestack",
   "main": "index.js",
   "author": "Noel Weichbrodt <noel@pylon.com>",


### PR DESCRIPTION
- `trace-level` uses a provided enum (and returns the java side to a much simpler implementation)
- renamed events for better clarity and match with `spokestack-android`
- added speech pipeline `activate` and `deactivate` methods