### PR TITLE
Handle iOS bundle reloading

### DIFF
--- a/RNSpokestack.podspec
+++ b/RNSpokestack.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/*.{h,m}'
   s.requires_arc = true
 
-  s.dependency "SpokeStack", "0.1.8"
+  s.dependency "SpokeStack", "0.1.10"
   s.dependency 'React'
 end

--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -116,6 +116,10 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config)
 
 RCT_EXPORT_METHOD(start)
 {
+    if (![_pipeline status]) {
+        NSLog(@"RNSpokestack start status was false");
+        [_pipeline setDelegates: self wakewordDelegate: self];
+    }
     [_pipeline start];
 }
 


### PR DESCRIPTION
use the new functions in spokestack-ios 0.1.10 to keep the pipeline setup intact after a bundle reload.