### PR TITLE
activate() and deactivate() send corresponding events

### DIFF
--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -134,21 +134,21 @@ RCT_EXPORT_METHOD(stop)
 RCT_REMAP_METHOD(activate, makeActive)
 {
     NSLog(@"RNSpokestack activate()");
+    [_pipeline activate];
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{@"event": @"activate", @"transcript": @"", @"error": @""}];
     }
-    [_pipeline activate];
 }
 
 RCT_REMAP_METHOD(deactivate, makeDeactive)
 {
     NSLog(@"RNSpokestack deactivate()");
+    [_pipeline deactivate];
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{@"event": @"deactivate", @"transcript": @"", @"error": @""}];
     }
-    [_pipeline deactivate];
 }
 
 @end

--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -133,12 +133,22 @@ RCT_EXPORT_METHOD(stop)
 
 RCT_REMAP_METHOD(activate, makeActive)
 {
-  [_pipeline activate];
+    NSLog(@"RNSpokestack activate()");
+    if (hasListeners)
+    {
+        [self sendEventWithName:@"onSpeechEvent" body:@{@"event": @"activate", @"transcript": @"", @"error": @""}];
+    }
+    [_pipeline activate];
 }
 
 RCT_REMAP_METHOD(deactivate, makeDeactive)
 {
-  [_pipeline deactivate];
+    NSLog(@"RNSpokestack deactivate()");
+    if (hasListeners)
+    {
+        [self sendEventWithName:@"onSpeechEvent" body:@{@"event": @"deactivate", @"transcript": @"", @"error": @""}];
+    }
+    [_pipeline deactivate];
 }
 
 @end


### PR DESCRIPTION
Keep in mind, like I found out with my test app, if you've hooked an `onActivate` listener to `activate` event that then calls something like `pipeline.activate()` or `pipeline.deactivate()`, you'll end up in a silly loop of freaking out.