### PR TITLE
Make initialize idempotent

### DIFF
--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -76,6 +76,9 @@ SpeechPipeline* _pipeline;
 
 RCT_EXPORT_METHOD(initialize:(NSDictionary *)config)
 {
+    if (_pipeline != nil) {
+        return;
+    }
     RecognizerService _recognizerService;
     RecognizerConfiguration *_recognizerConfig;
     WakewordService _wakewordService;
@@ -104,7 +107,7 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config)
     }
     _wakewordConfig.wakePhrases = ([config valueForKeyPath:@"properties.wake-phrases"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.wake-phrases"]] : _wakewordConfig.wakePhrases;
     _wakewordConfig.wakeWords = ([config valueForKeyPath:@"properties.wake-words"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.wake-words"]] : _wakewordConfig.wakeWords;
-    
+
     _pipeline = [[SpeechPipeline alloc] init: _recognizerService
                          speechConfiguration: _recognizerConfig
                               speechDelegate: self


### PR DESCRIPTION
- This avoids reinitializing when the pipeline has already been initialized. It seems the bridge behaves a bit differently on the iOS side, probably not even disconnecting on reload. However, the app has no way to know it's already initialized. I think checking if the pipeline is already there will fix multiple pipelines getting created.