### PR TITLE
Remove Google ASR support from iOS

### DIFF
--- a/RNSpokestack.podspec
+++ b/RNSpokestack.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/*.{h,m}'
   s.requires_arc = true
 
-  s.dependency "SpokeStack", "0.3.0"
+  s.dependency "SpokeStack", "1.0.0"
   s.dependency 'React'
 end

--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -96,14 +96,8 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config)
 
     // Speech
 
-    if ([[config valueForKey:@"stages"] containsObject:@"com.pylon.spokestack.google.GoogleSpeechRecognizer"]) { // For now, override RecognizerServiceGoogleSpeech;
-        _recognizerConfig = [[RecognizerConfiguration alloc] init]; //[[GoogleRecognizerConfiguration alloc] init];
-        // _recognizerConfig.apiKey = [RCTConvert NSString:[config valueForKeyPath:@"properties.google-api-key"]];
-        _recognizerService = RecognizerServiceAppleSpeech; // RecognizerServiceGoogleSpeech;
-    } else {
-        _recognizerConfig = [[RecognizerConfiguration alloc] init];
-        _recognizerService = RecognizerServiceAppleSpeech;
-    }
+    _recognizerConfig = [[RecognizerConfiguration alloc] init];
+    _recognizerService = RecognizerServiceAppleSpeech;
     _recognizerConfig.vadFallDelay = ([config valueForKeyPath:@"properties.vad-fall-delay"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"properties.vad-fall-delay"]] : _recognizerConfig.vadFallDelay;
 
     // Wakeword

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-spokestack",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "React Native wrapper for Spokestack",
   "main": "index.js",
   "author": "Noel Weichbrodt <noel@pylon.com>",


### PR DESCRIPTION
Updates the `spokestack-ios` dependency to 1.0.0 (first release without google asr support) and removes unused iOS google init.