### PR TITLE
New iOS callback for setupFailed event

### DIFF
--- a/RNSpokestack.podspec
+++ b/RNSpokestack.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/*.{h,m}'
   s.requires_arc = true
 
-  s.dependency "SpokeStack", "1.0.4"
+  s.dependency "SpokeStack", "1.0.5"
   s.dependency 'React'
 end

--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -74,6 +74,14 @@ SpeechPipeline* _pipeline;
     }
 }
 
+- (void)setupFailed:(NSString * _Nonnull)error {
+    NSLog(@"RNSpokestack setupFailed");
+    if (hasListeners)
+    {
+        [self sendEventWithName:@"onSpeechEvent" body:@{@"event": @"error", @"transcript": @"", @"error": error}];
+    }
+}
+
 - (void)didStart {
     NSLog(@"RNSpokestack didStart");
     if (hasListeners)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "react-native-spokestack",
-  "version": "0.0.4",
+  "version": "1.5.1",
   "lockfileVersion": 1
 }


### PR DESCRIPTION
The `spokestack-ios` pipeline may now throw an event specifically for failures during `initialize`. This is threaded into the existing `didError` event for the js interface.